### PR TITLE
bindey :: Add AlwaysUpdate policy and a safe_property type that uses the nod::signal

### DIFF
--- a/include/bindey/property.h
+++ b/include/bindey/property.h
@@ -7,10 +7,24 @@
 namespace bindey
 {
 
-template <typename T, typename UpdatePolicy = std::not_equal_to<T>>
+/**
+ * Optional AlwaysUpdate policy to notify subscribers everytime the property value is set, not just when it changes
+ */
+class AlwaysUpdate
+{
+public:
+    template <typename T>
+    bool operator()( const T&, const T& ) const
+    {
+        return true;
+    }
+};
+
+template <typename T, typename UpdatePolicy = std::not_equal_to<T>, typename Signal = nod::unsafe_signal<void( const T& )>>
 class property
 {
 public:
+    
     property()
     {
     }
@@ -71,7 +85,7 @@ public:
      * this signal is invoked whenever the the value changes per the UpdatePolicy
      * @discussion nod::unsafe_signal is used here for speed. Take care of your own threading.
      */
-    nod::unsafe_signal<void( const T& newValue )> changed;
+    Signal changed;
 
     /**
      * convience function to attach a change listener to this property
@@ -95,5 +109,11 @@ public:
 private:
     T mStorage{};
 };
+
+/**
+ * thread safe property type based on nod::signal
+ */
+template <typename T, typename UpdatePolicy = std::not_equal_to<T>>
+using safe_property = property<T, UpdatePolicy, nod::signal<void(const T&)>>;
 
 } // namespace bindey

--- a/include/bindey/property.h
+++ b/include/bindey/property.h
@@ -8,9 +8,9 @@ namespace bindey
 {
 
 /**
- * Optional AlwaysUpdate policy to notify subscribers everytime the property value is set, not just when it changes
+ * Optional always_update policy to notify subscribers everytime the property value is set, not just when it changes
  */
-class AlwaysUpdate
+class always_update
 {
 public:
     template <typename T>

--- a/test/property.test.cpp
+++ b/test/property.test.cpp
@@ -46,3 +46,57 @@ TEST_CASE( "Change Notitfcations" )
 
     boolProp.onChangedAndNow( [&]( const auto& val ) { REQUIRE( val == true ); } );
 }
+
+TEST_CASE( "Always Update" )
+{
+    bindey::property<bool, bindey::AlwaysUpdate> boolProp;
+    REQUIRE( boolProp() == false );
+    
+    int count = 0;
+    boolProp.onChanged([&]( const auto& val )
+    {
+        switch ( count )
+        {
+            case 0:
+                REQUIRE( val == true );
+                break;
+                
+            case 1:
+                REQUIRE( val == false );
+                break;
+                
+            case 2:
+                REQUIRE( val == false );
+                break;
+                
+            default:
+                FAIL( "callback should not have occured");
+                break;
+        }
+        
+        count++;
+    });
+    
+    boolProp( true );
+    
+    boolProp( false );
+    
+    boolProp( false );
+}
+
+TEST_CASE( "safe_property" )
+{
+    bindey::safe_property<bool> boolProp;
+    REQUIRE( boolProp.get() == false );
+
+    bool wasCalled = false;
+    boolProp.onChanged( [&]( const auto& ) { wasCalled = true; } );
+
+    boolProp.set( false );
+    REQUIRE( wasCalled == false );
+
+    boolProp.set( true );
+    REQUIRE( wasCalled == true );
+
+    boolProp.onChangedAndNow( [&]( const auto& val ) { REQUIRE( val == true ); });
+}

--- a/test/property.test.cpp
+++ b/test/property.test.cpp
@@ -49,7 +49,7 @@ TEST_CASE( "Change Notitfcations" )
 
 TEST_CASE( "Always Update" )
 {
-    bindey::property<bool, bindey::AlwaysUpdate> boolProp;
+    bindey::property<bool, bindey::always_update> boolProp;
     REQUIRE( boolProp() == false );
     
     int count = 0;


### PR DESCRIPTION
# What: 
* `property.h` doesn't have an easy to use AlwaysUpdate policy or a thread safe version

# How:
* Add the `AlwaysUpdate` declaration to `property.h`
* Make another aliased type called `safe_property` that uses the thread safe `nod::signal`